### PR TITLE
Fix for issue 7, move arm-ttk in action runs out from workdir

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -59,8 +59,8 @@ runs:
         Install-Module -Name Pester -RequiredVersion 4.10.1 -Force
         Import-Module -Name Pester -RequiredVersion 4.10.1 -Force
         Invoke-WebRequest -Uri ${{ inputs.armttkVersion }} -OutFile arm-template-toolkit.zip
-        Expand-Archive -LiteralPath arm-template-toolkit.zip -DestinationPath arm-ttk
-        Import-Module ./arm-ttk/arm-ttk/arm-ttk.psd1
+        Expand-Archive -LiteralPath arm-template-toolkit.zip -DestinationPath ../arm-ttk
+        Import-Module ../arm-ttk/arm-ttk/arm-ttk.psd1
         echo "Test-AzTemplate -TemplatePath ${{ inputs.workdir }} -Pester -Skip Secure-Params-In-Nested-Deployments" | Out-File -FilePath ./armttk.ps1
         Invoke-Pester -Script ./armttk.ps1 -EnableExit -OutputFormat NUnitXml -OutputFile ./armttk.xml
     - name: Publish Test Results


### PR DESCRIPTION
Keep arm-ttk out from the workdir to avoid Test-AzTemplate from pulling in arm-ttk's own JSON files. This solves following issue https://github.com/microsoft/action-armttk/issues/7 and makes sure that Test-AzTemplate run output is consistent with local runs.