### PR TITLE
Shahar/add retention to ttk result

### DIFF
--- a/.github/workflows/arm-ttk/action.yml
+++ b/.github/workflows/arm-ttk/action.yml
@@ -28,14 +28,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - run: az bicep build --file "$bicepFilePath" --outfile "$outputFilePath" > bicep.txt
         shell: bash
         env:
           bicepFilePath: "${{ inputs.workingPath }}/${{ inputs.bicepFile }}"
           outputFilePath: "${{ inputs.workingPath }}/mainTemplate.json"
       - name: Publish Bicep Compile Results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: BicepResults
           path: ./bicep.txt

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ jobs:
     name: runner / armttk
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: microsoft/action-armttk@v1
         with:
           github_token: ${{ secrets.github_token }}

--- a/action.yml
+++ b/action.yml
@@ -50,6 +50,10 @@ inputs:
     options:
     - aka.ms/arm-ttk-latest
     - aka.ms/arm-ttk-marketplace    
+  armttkResultsRetention:
+    description: "Number of days to retain ARM-TTK results"
+    required: false
+    default: 30
 runs:
   using: "composite"
   steps:
@@ -68,6 +72,7 @@ runs:
       with:
         name: ARMTTKResults
         path: ./armttk.xml
+        retention-days: ${{ inputs.armttkResultsRetention }}
       if: ${{ always() }}
     - run: $GITHUB_ACTION_PATH/entrypoint.sh
       shell: bash


### PR DESCRIPTION
1. This PR is adding a `retention-days` when uploading the result file to the GitHub artifactory.
2. Upgrade the versions of the GitHub actions. `actions/upload-artifact` in version v3 is using NodeJS 16, which will be deprecated soon.